### PR TITLE
Refactored DFS code to generator to make the code simpler

### DIFF
--- a/yaml_config_override/__init__.py
+++ b/yaml_config_override/__init__.py
@@ -1,55 +1,28 @@
-import copy
 import yaml
 from pathlib import Path
 import argparse
 
-
-def call_dict(diction, args):
-    args_list = args.split(".")
-    for arg in args_list:
-        diction = diction[arg]
-    return diction
-
-
-def update(diction, path, val):
-    if len(path) > 1:
-        update(diction[path[0]], path[1:], val)
-    else:
-        diction[path[0]] = val
-        return None
-
-
-def add_arguments(conf1=None):
-    parser = argparse.ArgumentParser()
-    if conf1 is None:
-        parser.add_argument("-c", "--config", type=Path)
-        args = vars(parser.parse_known_args()[0])
-        conf = yaml.safe_load(args["config"].read_text())
-    else:
-        conf = copy.deepcopy(conf1)
-    args_to_create = {}
-    dfs = []
-    visited = set()
-    root = list(conf.keys())
-    dfs = dfs + [str(x) for x in root]
-    while len(dfs) > 0:
-        cur = dfs.pop()
-        if cur in visited:
-            continue
-        visited.add(cur)
-        cur_call = call_dict(conf, cur)
-        if isinstance(call_dict(conf, cur), dict):
-            dfs = dfs + [str(cur) + "." + str(x) for x in list(cur_call.keys())]
+def __parse(config_specification, argument_root=None):
+    if argument_root is None:
+        argument_root = []
+    for key, value in config_specification.items():
+        if isinstance(value, dict):
+            yield from __parse(value, argument_root + [key])
         else:
-            args_to_create["--" + str(cur)] = type(cur_call)
+            yield '.'.join(argument_root + [key]) , value
 
-    for key, val in args_to_create.items():
-        parser.add_argument(key, type=val, required=False)
-    args = vars(parser.parse_args())
-    for key, val in args_to_create.items():
-        ckey = key[2:]
-        if args[ckey] is not None:
-            _list = ckey.split(".")
-            update(conf, _list, args[ckey])
-    return conf
+
+def add_arguments(config=None):
+    
+    parser = argparse.ArgumentParser()
+
+    if config is None:
+        parser.add_argument("-c", "--config", type=Path)
+        config = \
+            yaml.safe_load(parser.parse_known_args()[0].config.read_text())
+
+    for name, default_value in __parse(config):
+        parser.add_argument('--' + name, type=type(default_value), default=default_value)
+
+    return vars(parser.parse_args())
 


### PR DESCRIPTION
Rationale:

1. The add argument has two jobs: 1) Add argument specifications to parser 2) parsing the arguments
2. Moving it to a generator enables the use of single for loop to add variables to the parse the arguments and a single line to parse. This makes the intent extremely clear.
3. It removes unnecessary copies of `conf` variable.