### PR TITLE
Fixed override for bool arguments using str2bool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yaml_config_override"
-version = "0.2"
+version = "0.6"
 description = "Easy overriding of YAML configs"
 authors = ["sashank_tirumala <stsashank6@gmail.com>"]
 readme = "README.md"

--- a/yaml_config_override/__init__.py
+++ b/yaml_config_override/__init__.py
@@ -17,6 +17,16 @@ def update(diction, path, val):
     else:
         diction[path[0]] = val
         return None
+    
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    elif v.lower() in ("no", "false", "f", "n", "0"):
+        return False
+    else:
+        raise argparse.ArgumentTypeError("Boolean value expected for argument.")
 
 
 def add_arguments(conf1=None):
@@ -44,7 +54,10 @@ def add_arguments(conf1=None):
             args_to_create["--" + str(cur)] = type(cur_call)
 
     for key, val in args_to_create.items():
-        parser.add_argument(key, type=val, required=False)
+        if val == bool:
+            parser.add_argument(key, type=str2bool, required=False)
+        else:
+            parser.add_argument(key, type=val, required=False)
     args = vars(parser.parse_args())
     for key, val in args_to_create.items():
         ckey = key[2:]
@@ -52,4 +65,3 @@ def add_arguments(conf1=None):
             _list = ckey.split(".")
             update(conf, _list, args[ckey])
     return conf
-


### PR DESCRIPTION
Hi,

First of all thank you for the library. I find it very useful in my workflow. I just found no way to override boolean variables in the config. This pull request try to fix the problem using str2bool function if the element is supposed to be boolean.

Hope I didn't miss anything.