### PR TITLE
Replace hyphen with underscore

### DIFF
--- a/yaml_config_override/__init__.py
+++ b/yaml_config_override/__init__.py
@@ -60,7 +60,7 @@ def add_arguments(conf1=None):
             parser.add_argument(key, type=val, required=False)
     args = vars(parser.parse_args())
     for key, val in args_to_create.items():
-        ckey = key[2:]
+        ckey = key[2:].replace('-','_')
         if args[ckey] is not None:
             _list = ckey.split(".")
             update(conf, _list, args[ckey])


### PR DESCRIPTION
Argparse doesn't support hyphen in argument names, so if the YAML config contains hyphenated keys, yaml_config_override won't find a matching key name.

```
Traceback (most recent call last):
  ...
  File "/usr/local/lib/python3.8/site-packages/yaml_config_override/__init__.py", line 52, in add_arguments
    if args[ckey] is not None:
KeyError: 'foo.bar-baz'
```